### PR TITLE
Auto, Random and Safe Port choosing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.venv
+.idea
+.run
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/app/utils/fastapi_lifespan.py
+++ b/app/utils/fastapi_lifespan.py
@@ -3,14 +3,13 @@ import webbrowser
 from typing import AsyncGenerator
 
 from app.core import settings
-from app.utils.network_util import get_server_url
+from app.utils.network_util import get_server_url, choose_port
 from app.utils.qrcode_util import generate_qr_code
 
 
-async def lifespan(app) -> AsyncGenerator:
+async def lifespan(app, port) -> AsyncGenerator:
     # Startup actions
-
-    url = get_server_url()
+    url = get_server_url(port)
 
     print(f" Welcome to Mizban 🚀 \n Your lightweight & fast file-sharing server \n\n")
     print(f" Mizban uses {settings.UPLOAD_DIR} as the shared folder. \n")

--- a/app/utils/network_util.py
+++ b/app/utils/network_util.py
@@ -1,5 +1,6 @@
 import socket
 import sys
+from random import randint
 
 
 def _get_ip_address():
@@ -16,8 +17,21 @@ def _get_ip_address():
 
 
 
-def get_server_url():
+def get_server_url(port: int):
     ip = _get_ip_address()
-    url = f'http://{ip}:8000/'
+    url = f'http://{ip}:{port}/'
 
     return url
+
+def is_port_busy(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    result = sock.connect_ex(('127.0.0.1', port))
+    sock.close()
+    return result == 0
+
+def choose_port() -> int:
+    while True:
+        port = randint(10000, 65500)
+        if not is_port_busy(port):
+            return port

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import sys
+from functools import partial
+
 import uvicorn
 
 from fastapi import FastAPI
@@ -8,10 +10,11 @@ from fastapi.staticfiles import StaticFiles
 from app.api import files_router
 from app.core import settings
 from app.utils import lifespan, initialize_shared_folder
-
+from app.utils.network_util import choose_port
 
 initialize_shared_folder(settings.UPLOAD_DIR)
-app = FastAPI(lifespan=lifespan)
+port = choose_port()
+app = FastAPI(lifespan=partial(lifespan, port=port))
 
 app.add_middleware(
     CORSMiddleware,
@@ -32,7 +35,7 @@ if __name__ == "__main__":
     uvicorn.run(
         app=app,
         host="0.0.0.0",
-        port=8000,
+        port=port,
         loop=async_loop,
         http="httptools",
         log_level="critical"


### PR DESCRIPTION
I was using it when I noticed a problem.
If port **8000** was busy with another service, it would fail.

At first I tried to leave the port selection process to the **user**.
But I noticed that you get single executable files as output from this source code. I decided to make the port selection **automatic** and **random** from **free ports**.