### PR TITLE
 feat : Dark and Light mode added to the mizban

### DIFF
--- a/web/css/output.css
+++ b/web/css/output.css
@@ -959,4 +959,154 @@ video {
   }
 }
 
+:root {
+  color-scheme: light;
+  --bg-page: #fafafa;
+  --bg-surface: #ffffff;
+  --text-primary: #111827;
+  --text-muted: #6b7280;
+  --panel-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  --panel-border: #d1d5db;
+  --dropzone-border: #d1d5db;
+  --dropzone-text: #9ca3af;
+  --dropzone-hover: #eff6ff;
+  --file-card-bg: #f3f4f6;
+  --file-card-text: #374151;
+  --file-card-hover: #24acd1;
+  --file-card-hover-text: #ffffff;
+  --error-bg: #f3f4f6;
+  --toggle-bg: #ffffff;
+  --toggle-border: #d1d5db;
+  --toggle-text: #111827;
+  --toggle-hover: #f3f4f6;
+  --scroll-track: #f1f1f1;
+  --scroll-thumb: #a0aec0;
+  --scroll-thumb-border: #f1f1f1;
+  --progress-track: #e5e7eb;
+}
 
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg-page: #0f172a;
+  --bg-surface: #111827;
+  --text-primary: #f9fafb;
+  --text-muted: #94a3b8;
+  --panel-shadow: 0 18px 38px rgba(2, 6, 23, 0.55);
+  --panel-border: #334155;
+  --dropzone-border: #334155;
+  --dropzone-text: #94a3b8;
+  --dropzone-hover: #1e293b;
+  --file-card-bg: #1f2937;
+  --file-card-text: #e5e7eb;
+  --file-card-hover: #2563eb;
+  --file-card-hover-text: #f9fafb;
+  --error-bg: #1f2937;
+  --toggle-bg: #111827;
+  --toggle-border: #334155;
+  --toggle-text: #e5e7eb;
+  --toggle-hover: #1f2937;
+  --scroll-track: #1f2937;
+  --scroll-thumb: #475569;
+  --scroll-thumb-border: #1f2937;
+  --progress-track: #334155;
+}
+
+html,
+body {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-body {
+  background-color: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.app-subtitle {
+  color: var(--text-muted);
+}
+
+.app-panel {
+  background-color: var(--bg-surface);
+  border: 1px dashed var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  transition: background-color 0.2s ease, box-shadow 0.4s ease, border-color 0.6s ease;
+}
+
+.drop-zone {
+  border-color: var(--dropzone-border);
+  color: var(--dropzone-text);
+  background-color: transparent;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  min-width: 104px;
+  padding: 0.5rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--toggle-border);
+  background-color: var(--toggle-bg);
+  color: var(--toggle-text);
+  font-size: 0.875rem;
+  line-height: 1.2;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--toggle-hover);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid #24acd1;
+  outline-offset: 2px;
+}
+
+.file-card {
+  background-color: var(--file-card-bg);
+  color: var(--file-card-text);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.file-card:hover {
+  background-color: var(--file-card-hover);
+  color: var(--file-card-hover-text);
+}
+
+.app-error-container {
+  background-color: var(--error-bg);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  min-height: 2.25rem;
+  transition: background-color 0.2s ease;
+}
+
+.app-error-container:empty {
+  display: none;
+  padding: 0;
+  min-height: 0;
+}
+
+.upload-progress-track {
+  background-color: var(--progress-track);
+}
+
+.file-list-pad {
+  /* Slightly smaller than old p-2 (8px), equal on both axes */
+  padding: 10px;
+}
+
+#fileList::-webkit-scrollbar-track {
+  background: var(--scroll-track);
+}
+
+#fileList::-webkit-scrollbar-thumb {
+  background-color: var(--scroll-thumb);
+  border: 2px solid var(--scroll-thumb-border);
+}
+
+#dropZone:hover,
+#dropZone.drag-over {
+  background-color: var(--dropzone-hover);
+}

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -2,55 +2,194 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: light;
+  --bg-page: #fafafa;
+  --bg-surface: #ffffff;
+  --text-primary: #111827;
+  --text-muted: #6b7280;
+  --panel-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  --panel-border: #d1d5db;
+  --dropzone-border: #d1d5db;
+  --dropzone-text: #9ca3af;
+  --dropzone-hover: #eff6ff;
+  --file-card-bg: #f3f4f6;
+  --file-card-text: #374151;
+  --file-card-hover: #24acd1;
+  --file-card-hover-text: #ffffff;
+  --error-bg: #f3f4f6;
+  --toggle-bg: #ffffff;
+  --toggle-border: #d1d5db;
+  --toggle-text: #111827;
+  --toggle-hover: #f3f4f6;
+  --scroll-track: #f1f1f1;
+  --scroll-thumb: #a0aec0;
+  --scroll-thumb-border: #f1f1f1;
+  --progress-track: #e5e7eb;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg-page: #0f172a;
+  --bg-surface: #111827;
+  --text-primary: #f9fafb;
+  --text-muted: #94a3b8;
+  --panel-shadow: 0 18px 38px rgba(2, 6, 23, 0.55);
+  --panel-border: #334155;
+  --dropzone-border: #334155;
+  --dropzone-text: #94a3b8;
+  --dropzone-hover: #1e293b;
+  --file-card-bg: #1f2937;
+  --file-card-text: #e5e7eb;
+  --file-card-hover: #2563eb;
+  --file-card-hover-text: #f9fafb;
+  --error-bg: #1f2937;
+  --toggle-bg: #111827;
+  --toggle-border: #334155;
+  --toggle-text: #e5e7eb;
+  --toggle-hover: #1f2937;
+  --scroll-track: #1f2937;
+  --scroll-thumb: #475569;
+  --scroll-thumb-border: #1f2937;
+  --progress-track: #334155;
+}
+
+html,
+body {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-body {
+  background-color: var(--bg-page);
+  color: var(--text-primary);
+}
+
 .container {
-    max-width: 91.6667%;
-    margin: 0 auto;
-    /* padding: 0 20px; */
-  }
-  
-  @media (min-width: 768px) {
-    .container {
-      max-width: 1280px;
-    }
-  }
+  max-width: 91.6667%;
+  margin: 0 auto;
+  /* padding: 0 20px; */
+}
 
-  .font-oswald {
-    font-family: 'Oswald', sans-serif;
+@media (min-width: 768px) {
+  .container {
+    max-width: 1280px;
   }
+}
 
-  .font-outfit {
-    font-family: 'Outfit', sans-serif;
-  }
-  
-  
-  /* Enhanced no-scrollbar */
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-  
-  .no-scrollbar {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  
-  /* Custom scrollbar style */
-  #fileList::-webkit-scrollbar {
-    width: 8px;
-  }
-  
-  #fileList::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
-  }
-  
-  #fileList::-webkit-scrollbar-thumb {
-    background-color: #a0aec0;
-    border-radius: 4px;
-    border: 2px solid #f1f1f1;
-  }
-  #dropZone:hover,
+.font-oswald {
+  font-family: 'Oswald', sans-serif;
+}
+
+.font-outfit {
+  font-family: 'Outfit', sans-serif;
+}
+
+.app-subtitle {
+  color: var(--text-muted);
+}
+
+.app-panel {
+  background-color: var(--bg-surface);
+  border: 1px dashed var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.drop-zone {
+  border-color: var(--dropzone-border);
+  color: var(--dropzone-text);
+  background-color: transparent;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  min-width: 104px;
+  padding: 0.5rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--toggle-border);
+  background-color: var(--toggle-bg);
+  color: var(--toggle-text);
+  font-size: 0.875rem;
+  line-height: 1.2;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--toggle-hover);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid #24acd1;
+  outline-offset: 2px;
+}
+
+.file-card {
+  background-color: var(--file-card-bg);
+  color: var(--file-card-text);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.file-card:hover {
+  background-color: var(--file-card-hover);
+  color: var(--file-card-hover-text);
+}
+
+.app-error-container {
+  background-color: var(--error-bg);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  min-height: 2.25rem;
+  transition: background-color 0.2s ease;
+}
+
+.app-error-container:empty {
+  display: none;
+  padding: 0;
+  min-height: 0;
+}
+
+.upload-progress-track {
+  background-color: var(--progress-track);
+}
+
+.file-list-pad {
+  /* Slightly smaller than old p-2 (8px), equal on both axes */
+  padding: 6px;
+}
+
+/* Enhanced no-scrollbar */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+/* Custom scrollbar style */
+#fileList::-webkit-scrollbar {
+  width: 8px;
+}
+
+#fileList::-webkit-scrollbar-track {
+  background: var(--scroll-track);
+  border-radius: 4px;
+}
+
+#fileList::-webkit-scrollbar-thumb {
+  background-color: var(--scroll-thumb);
+  border-radius: 4px;
+  border: 2px solid var(--scroll-thumb-border);
+}
+
+#dropZone:hover,
 #dropZone.drag-over {
-    display: flex !important;
+  display: flex !important;
+  background-color: var(--dropzone-hover);
 }
 
 .spinner {
@@ -75,4 +214,3 @@
   background: linear-gradient(90deg, rgba(66,153,225,0) 0%, rgba(66,153,225,0.5) 50%, rgba(66,153,225,0) 100%);
   animation: indeterminate 1.5s infinite linear;
 }
-

--- a/web/index.html
+++ b/web/index.html
@@ -4,43 +4,60 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mizban - LAN File Sharing</title>
+    <script>
+      (() => {
+        const key = 'mizban-theme';
+        try {
+          const stored = localStorage.getItem(key);
+          const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const theme = stored === 'dark' || (stored === null && prefersDark) ? 'dark' : 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (_err) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/output.css">
   </head>
-  
-<body class="bg-[#FAFAFA]">
+
+<body class="app-body">
   <header class="w-full p-6">
     <div class="flex items-center gap-4 container">
-      <img src="icons/server_image.svg" alt="logo" class="w-14">
-      <div class="flex flex-col">
-        <b><h1 class="font-outfit text-2xl">Mizban</h1></b>
-        <p class="font-oswald oswald-light">LAN File Sharing Solution</p>
-
+      <div class="flex items-center gap-4">
+        <img src="icons/server_image.svg" alt="logo" class="w-14">
+        <div class="flex flex-col">
+          <h1 class="font-outfit text-2xl"><b>Mizban</b></h1>
+          <p class="font-oswald oswald-light app-subtitle">LAN File Sharing Solution</p>
+        </div>
       </div>
+      <button id="themeToggle" type="button" class="theme-toggle font-outfit" aria-label="Toggle dark mode" aria-pressed="false">
+        <span id="themeToggleText">Dark mode</span>
+      </button>
     </div>
   </header>
-  
+
   <main>
     <button id="uploadButton" class="container flex justify-center items-center text-white mt-6 py-2 gap-4 rounded-3xl bg-gradient-to-r from-primary to-secondary hover:from-[#24ACD1] hover:to-[#4B5094] transition-all duration-200">
       <img src="icons/upload_icon.png" alt="upload_icon" class="w-10">
       <p class="text-2xl font-oswald">Upload File</p>
-   </button>
-   
-   <section class="w-full  mt-6">
-    <input type="file" id="fileInput" class="hidden w-full" multiple>
-     <div class=" container rounded-lg bg-[#FFFFFF] shadow-lg relative h-[600px] md:h-[450px]">
-       <div id="dropZone" class="hidden h-full w-full justify-center items-center border-2 text-2xl border-dashed border-gray-300 rounded-lg text-center text-gray-400 hover:bg-blue-50 transition-all duration-200 z-20 opacity-90">
-        Drag and drop files here, or click the upload button above.
-       </div>
-   
-       <div id="fileList" class="mt-4 grid grid-cols-2 md:grid-cols-8 gap-4 overflow-y-auto relative z-10 max-h-[570px] md:max-h-[420px] p-2"></div>
-  </section>
-  </div>
+    </button>
+
+    <section class="w-full mt-6">
+      <input type="file" id="fileInput" class="hidden w-full" multiple>
+      <div class="container rounded-lg app-panel relative h-[600px] md:h-[450px]">
+        <div id="dropZone" class="drop-zone hidden h-full w-full justify-center items-center border-2 text-2xl border-dashed rounded-lg text-center transition-all duration-200 z-20 opacity-90">
+          Drag and drop files here, or click the upload button above.
+        </div>
+
+        <div id="fileList" class="mt-1 grid grid-cols-2 md:grid-cols-8 gap-4 overflow-y-auto relative z-10 max-h-[570px] md:max-h-[420px] file-list-pad"></div>
+      </div>
+    </section>
 
     <!-- Error Container -->
-    <div id="errorContainer" class="container bg-gray-100 text-red-500 mt-2"></div>
+    <div id="errorContainer" class="container app-error-container mt-2"></div>
   </main>
-  
+
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Here’s a summary of the changes made:

1. Dark mode was added end-to-end.
   - Theme toggle button added in header (`web/index.html`).
   - Theme state logic added with `localStorage` persistence (`web/script.js`).
   - Initial theme is applied early to avoid flash on load (`web/index.html` inline script).

2. Theme styling system added.
   - Light/dark CSS variables and component styles added (`web/css/styles.css` and mirrored in `web/css/output.css`).
   - New themed UI classes: `app-body`, `app-panel`, `drop-zone`, `app-error-container`, `file-card`, `upload-progress-track`.

3. Dynamic UI was updated to follow theme.
   - File cards now use `file-card` class.
   - Upload progress track now uses `upload-progress-track`.
   - Error container uses themed style.

4. Theme button alignment was adjusted.
   - Button is now in the same header row, right-aligned, and vertically aligned with Mizban icon/text.

5. Panel visual tweak.
   - Added a thin dashed gray border to the upload panel (`app-panel`) with dark-mode-compatible color.

6. File list spacing tweak.
   - Replaced old `p-2` with `file-list-pad` (`padding: 6px`) for slightly tighter, equal x/y spacing.
   - `fileList` top margin is now `mt-1`.

